### PR TITLE
fix(app): emit declaration files and fix package type exports for external consumers

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -6,20 +6,19 @@
   "main": "dist/index.js",
   "exports": {
     ".": {
-      "types": "./src/index.ts",
+      "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
       "default": "./dist/index.js"
     }
   },
   "files": [
-    "dist",
-    "src"
+    "dist"
   ],
   "publishConfig": {
     "access": "public"
   },
   "scripts": {
-    "build": "vite build",
+    "build": "vite build && tsc -p tsconfig.build.json",
     "dev": "vite build --watch",
     "lint": "npx @ton-ai-core/vibecode-linter src/",
     "lint:tests": "npx @ton-ai-core/vibecode-linter tests/",
@@ -27,7 +26,8 @@
     "lint:types": "./scripts/lint-types.sh",
     "check": "tsc --noEmit",
     "test": "vitest run",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test:consumer": "tsc -p tests/consumer/tsconfig.json"
   },
   "repository": {
     "type": "git",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -27,7 +27,7 @@
     "check": "tsc --noEmit",
     "test": "vitest run",
     "typecheck": "tsc --noEmit",
-    "test:consumer": "tsc -p tests/consumer/tsconfig.json"
+    "test:consumer": "tsc -p tsconfig.build.json && tsc -p tests/consumer/tsconfig.json"
   },
   "repository": {
     "type": "git",

--- a/packages/app/tests/consumer/index.ts
+++ b/packages/app/tests/consumer/index.ts
@@ -18,6 +18,5 @@ type Paths = {
 
 const client = createClientEffect<Paths>()
 
-// Verify .GET exists and returns something (compile-time check only)
-const _result = client.GET("/health")
-void _result
+// Verify .GET exists and returns something (compile-time only)
+client.GET("/health")

--- a/packages/app/tests/consumer/index.ts
+++ b/packages/app/tests/consumer/index.ts
@@ -1,0 +1,23 @@
+// Consumer proof: external project imports createClientEffect and compiles with tsc --noEmit.
+// This file must compile cleanly with no local module declaration overrides.
+import { createClientEffect } from "@prover-coder-ai/openapi-effect"
+
+type Paths = {
+  "/health": {
+    get: {
+      responses: {
+        200: {
+          content: {
+            "application/json": { ok: boolean }
+          }
+        }
+      }
+    }
+  }
+}
+
+const client = createClientEffect<Paths>()
+
+// Verify .GET exists and returns something (compile-time check only)
+const _result = client.GET("/health")
+void _result

--- a/packages/app/tests/consumer/tsconfig.json
+++ b/packages/app/tests/consumer/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "noEmit": true,
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "target": "ES2022",
+    "lib": ["ES2022", "DOM"],
+    "verbatimModuleSyntax": true,
+    "paths": {
+      "@prover-coder-ai/openapi-effect": ["../../dist/index.d.ts"]
+    }
+  },
+  "include": ["index.ts"]
+}

--- a/packages/app/tests/consumer/tsconfig.json
+++ b/packages/app/tests/consumer/tsconfig.json
@@ -7,6 +7,7 @@
     "target": "ES2022",
     "lib": ["ES2022", "DOM"],
     "verbatimModuleSyntax": true,
+    "baseUrl": ".",
     "paths": {
       "@prover-coder-ai/openapi-effect": ["../../dist/index.d.ts"]
     }

--- a/packages/app/tsconfig.build.json
+++ b/packages/app/tsconfig.build.json
@@ -1,0 +1,18 @@
+{
+	"extends": "../../tsconfig.base.json",
+	"compilerOptions": {
+		"rootDir": "src",
+		"outDir": "dist",
+		"declaration": true,
+		"declarationMap": true,
+		"emitDeclarationOnly": true,
+		"lib": ["ES2022", "DOM", "DOM.Iterable"],
+		"types": ["node"]
+	},
+	"include": ["src/**/*"],
+	"exclude": [
+		"src/examples/**/*",
+		"node_modules",
+		"dist"
+	]
+}

--- a/packages/app/tsconfig.json
+++ b/packages/app/tsconfig.json
@@ -28,6 +28,7 @@
 	],
 	"exclude": [
 		"dist",
-		"node_modules"
+		"node_modules",
+		"tests/consumer"
 	]
 }


### PR DESCRIPTION
- Add tsconfig.build.json that emits .d.ts only from src/ (excludes examples with test fixture imports)
- Change build script to vite build && tsc -p tsconfig.build.json so declarations survive Vite's dist clean
- Point exports.types from ./src/index.ts to ./dist/index.d.ts so consumers get compiled declarations
- Remove src/ from published files — only dist/ is shipped
- Add tests/consumer/ fixture with strict tsconfig and proof-obligation import to pass tsc --noEmit

Closes #25

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
